### PR TITLE
varying fixes + addition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,10 +497,10 @@ if (NOT DISABLE_GRAPHICS)
     target_include_directories(${PROJECT_NAME} PUBLIC ${FREETYPE_INCLUDE_DIRS})
     # FFMPEG
     if (NOT DISABLE_VIDEO)
-        target_include_directories(${PROJECT_NAME} PUBLIC ${FFMPEG_INCLUDE_DIRS})
-        target_link_libraries(${PROJECT_NAME} PUBLIC ${FFMPEG_LIBRARIES})
+        target_include_directories(umfeld-lib PUBLIC ${FFMPEG_INCLUDE_DIRS})
+        target_link_libraries(umfeld-lib PUBLIC ${FFMPEG_LIBRARIES})
         if (APPLE)
-            target_link_libraries(${PROJECT_NAME} PUBLIC
+            target_link_libraries(umfeld-lib PUBLIC
                     "-framework AVFoundation"
                     "-framework Foundation"
                     "-framework CoreMedia"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,21 +42,21 @@ endif (APPLE)
 ##########################################################################################################
 ### CHECK FOR MACPORTS                                                                                 ###
 ##########################################################################################################
-if (APPLE AND NOT BREW_FOUND)
-    if (EXISTS "/opt/local/bin/port")
-        message(STATUS "MACPORTS found, setting paths.")
-        # 1. MacPorts 라이브러리 경로를 link_directories에 추가
-        link_directories("/opt/local/lib")
+if (APPLE AND EXISTS "/opt/local/bin/port")
+    message(STATUS "MACPORTS found, setting paths.")
+    # 1. Add MacPorts library path to link_directories
+    link_directories("/opt/local/lib")
 
-        # 2. pkg-config가 MacPorts 라이브러리를 찾을 수 있도록 환경 변수 설정
-        set(ENV{PKG_CONFIG_PATH} "/opt/local/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+    # 2. Set environment variable so pkg-config can find MacPorts libraries
+    set(ENV{PKG_CONFIG_PATH} "/opt/local/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
 
-        # 참고: MacPorts 헤더 파일 경로 추가
-        include_directories("/opt/local/include")
-    else()
+    # Note: Add MacPorts header file path
+    include_directories("/opt/local/include")
+else()
+    if (APPLE AND NOT BREW_FOUND)
         message(WARNING "Neither HOMEBREW nor MACPORTS found. Build may fail.")
     endif()
-endif(APPLE AND NOT BREW_FOUND)
+endif()
 
 ##########################################################################################################
 ### SUPPLEMENT LIBRARY SEARCH PATH                                                                     ###
@@ -562,6 +562,16 @@ function(add_umfeld_libs)
     set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_link_libraries(${PROJECT_NAME} PRIVATE umfeld-lib-interface)
     target_link_libraries(${PROJECT_NAME} PRIVATE umfeld-lib)
+
+    # Add library search paths for macOS package managers
+    if (APPLE)
+        if (HOMEBREW_LIB_PATH)
+            target_link_directories(${PROJECT_NAME} PRIVATE ${HOMEBREW_LIB_PATH})
+        endif ()
+        if (EXISTS "/opt/local/bin/port")
+            target_link_directories(${PROJECT_NAME} PRIVATE "/opt/local/lib")
+        endif ()
+    endif ()
 
     # pffft SIMD detection
     # TODO maybe make this more platform specific?

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.20)
 
 project(umfeld-lib)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 message(STATUS "----------------------------------------")
 message(STATUS "UMFELD LIBRARY")
 message(STATUS "----------------------------------------")
@@ -35,6 +38,25 @@ if (APPLE)
         message(WARNING "HOMEBREW not found.")
     endif ()
 endif (APPLE)
+
+##########################################################################################################
+### CHECK FOR MACPORTS                                                                                 ###
+##########################################################################################################
+if (APPLE AND NOT BREW_FOUND)
+    if (EXISTS "/opt/local/bin/port")
+        message(STATUS "MACPORTS found, setting paths.")
+        # 1. MacPorts 라이브러리 경로를 link_directories에 추가
+        link_directories("/opt/local/lib")
+
+        # 2. pkg-config가 MacPorts 라이브러리를 찾을 수 있도록 환경 변수 설정
+        set(ENV{PKG_CONFIG_PATH} "/opt/local/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+
+        # 참고: MacPorts 헤더 파일 경로 추가
+        include_directories("/opt/local/include")
+    else()
+        message(WARNING "Neither HOMEBREW nor MACPORTS found. Build may fail.")
+    endif()
+endif(APPLE AND NOT BREW_FOUND)
 
 ##########################################################################################################
 ### SUPPLEMENT LIBRARY SEARCH PATH                                                                     ###

--- a/include/Geometry.h
+++ b/include/Geometry.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <array>
 #include <algorithm>
 #include <vector>
 #include <glm/gtc/matrix_transform.hpp>

--- a/include/UmfeldFunctions.h
+++ b/include/UmfeldFunctions.h
@@ -222,6 +222,7 @@ namespace umfeld {
     float    hue(uint32_t color);
     float    saturation(uint32_t color);
     uint32_t lerpColor(uint32_t c1, uint32_t c2, float amt);
+    void     rgb_to_hsb(const float r, const float g, const float b, float& h, float& s, float& v);
 
     // ## Environment
 

--- a/installation/install-arch.sh
+++ b/installation/install-arch.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# fail fast if any command fails and elevate privileges
+set -e
+echo "--- requesting sudo access once"
+sudo -v
+# keep-alive: update existing `sudo` time stamp until script is done
+# (this runs in background and exits when this script finishes)
+while true; do sudo -n true; sleep 60; done 2>/dev/null &
+KEEP_SUDO_ALIVE_PID="$!"
+# trap exit to clean up background sudo keeper
+trap 'kill "$KEEP_SUDO_ALIVE_PID"' EXIT
+
+echo "--- updating pacman"
+sudo pacman -Syu --noconfirm
+
+echo "--- installing dependencies (Arch Linux)"
+sudo pacman -S --noconfirm --needed \
+  git \
+  clang \
+  cmake \
+  curl \
+  mesa \
+  libxext \
+  libxrandr \
+  libxcursor \
+  libxi \
+  libxinerama \
+  wayland \
+  libxkbcommon \
+  wayland-protocols
+
+echo "--- installing umfeld dependencies"
+sudo pacman -S --noconfirm --needed \
+  pkg-config \
+  ffmpeg \
+  harfbuzz \
+  freetype2 \
+  rtmidi \
+  glm \
+  portaudio \
+  cairo \
+  libcurl-gnutls \
+  ncurses
+
+# install SDL3 from source into system
+echo "--- building SDL3 from source..."
+
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR"
+
+git clone --depth=1 https://github.com/libsdl-org/SDL.git
+cd SDL
+
+cmake -S . -B build \
+  -DSDL_KMSDRM=ON \
+  -DSDL_OPENGL=ON \
+  -DSDL_OPENGLES=ON \
+  -DSDL_WAYLAND=ON \
+  -DSDL_X11=ON \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+sudo cmake --install build
+
+echo "--- testing SDL3 pkg-config:"
+pkg-config --libs --cflags sdl3
+
+cd ~
+rm -rf "$TMP_DIR"
+echo "--- installed SDL3 successfully"
+
+echo "--- Arch Linux environment set up for 'umfeld'."
+echo

--- a/src/Movie.cpp
+++ b/src/Movie.cpp
@@ -310,7 +310,11 @@ bool Movie::available() {
 #endif
                 }
 
+#if LIBAVUTIL_VERSION_MAJOR >= 57
                 int channels    = audioCodecContext->ch_layout.nb_channels;
+#else
+                int channels    = audioCodecContext->channels;
+#endif
                 int out_samples = av_rescale_rnd(
                     swr_get_delay(swrCtx, frame->sample_rate) + frame->nb_samples,
                     frame->sample_rate, frame->sample_rate, AV_ROUND_UP);
@@ -331,10 +335,14 @@ bool Movie::available() {
                 // Process the float audio samples
                 // process_audio_samples(output_buffer, samples_converted, frame->ch_layout.nb_channels);
                 // std::cout << "+++ audio samples : " << samples_converted << std::endl;
-                // std::cout << "+++       channels: " << frame->ch_layout.nb_channels << std::endl;
+                // std::cout << "+++       channels: " << frame->channels << std::endl;
 
                 if (fListener) {
+#if LIBAVUTIL_VERSION_MAJOR >= 57
                     fListener->movieAudioEvent(this, output_buffer, samples_converted, frame->ch_layout.nb_channels);
+#else
+                    fListener->movieAudioEvent(this, output_buffer, samples_converted, frame->channels);
+#endif
                 }
 
                 // Free the output buffer


### PR DESCRIPTION
// summarized by copilot

### Build System Updates:
* **Set C++ Standard**: Added `CMAKE_CXX_STANDARD` to enforce C++17 as the required standard in `CMakeLists.txt`.
* **macOS Package Manager Support**: Added support for MacPorts by setting library paths, environment variables, and include directories when MacPorts is detected. A warning is issued if neither Homebrew nor MacPorts is found.
* **Target Linking for macOS**: Adjusted target linking in `CMakeLists.txt` to ensure `umfeld-lib` is explicitly referenced instead of `${PROJECT_NAME}` for clarity and consistency.
* **Library Search Paths**: Added logic in `add_umfeld_libs` to include MacPorts and Homebrew library paths when building on macOS.

### Installation Script:
* **New Arch Linux Script**: Introduced `install-arch.sh` to automate the setup of dependencies and build SDL3 from source for Arch Linux environments.

### Codebase Enhancements:
* **Library Compatibility**: Updated `Movie.cpp` to handle differences in FFmpeg's `libavutil` API by conditionally using `ch_layout.nb_channels` or `channels`, depending on the library version. [[1]](diffhunk://#diff-a5a32bfb18990f6b6e14d56af2cff02fc6270684706307967cddfbbe69d0832cR313-R317) [[2]](diffhunk://#diff-a5a32bfb18990f6b6e14d56af2cff02fc6270684706307967cddfbbe69d0832cL334-R345)
* **New Utility Function**: Added the missing definition of `rgb_to_hsb` to `UmfeldFunctions.h`, because there was only the implementation in the source file.

### Minor Updates:
* **Header Update**: Included `<array>` in `Geometry.h` explicitly. 