### PR TITLE
fix: vector length calculation

### DIFF
--- a/include/Geometry.h
+++ b/include/Geometry.h
@@ -515,7 +515,7 @@ namespace umfeld {
                 s.next_position = glm::vec2(line_strip[ii].x, line_strip[ii].y);
             }
             s.direction = s.next_position - s.position;
-            if (s.direction.x * s.direction.x + s.direction.y + s.direction.y > 0.0001f * 0.0001f) {
+            if (s.direction.x * s.direction.x + s.direction.y * s.direction.y > 0.0001f * 0.0001f) {
                 s.direction = glm::normalize(s.direction);
                 s.normal    = glm::vec2(-s.direction.y, s.direction.x);
             } else {


### PR DESCRIPTION
- possible a typo? the proper operator here is *, not +
- this was causing a wrong normal calculation
- found it when trying to draw a thick stroke


`./include/Geometry.h` line number 518:

```cpp
                s.next_position = glm::vec2(line_strip[ii].x, line_strip[ii].y);
                s.next_position = glm::vec2(line_strip[ii].x, line_strip[ii].y);
            }
            }
            s.direction = s.next_position - s.position;
            s.direction = s.next_position - s.position;
            if (s.direction.x * s.direction.x + s.direction.y + s.direction.y > 0.0001f * 0.0001f) { 
            if (s.direction.x * s.direction.x + s.direction.y * s.direction.y > 0.0001f * 0.0001f) {
                s.direction = glm::normalize(s.direction);
                s.direction = glm::normalize(s.direction);
                s.normal    = glm::vec2(-s.direction.y, s.direction.x);
                s.normal    = glm::vec2(-s.direction.y, s.direction.x);
            } else {
```


fixed this line:
`            if (s.direction.x * s.direction.x + s.direction.y + s.direction.y > 0.0001f * 0.0001f) { `
to this:
`            if (s.direction.x * s.direction.x + s.direction.y * s.direction.y > 0.0001f * 0.0001f) { `